### PR TITLE
Fix expbus pnr

### DIFF
--- a/trn/transitLines.access
+++ b/trn/transitLines.access
@@ -141,82 +141,81 @@
     7889    11471
 
 ;######################### From: M:\\Application\\Model One\\Networks\\TM1_2015_Base_Network\trn\transit_support\express_bus_neti_access_links.dat
-
-   12831     3807 ; Fremont: Mission @ I-580  ** Service for 2000 RVAL00. SI. 8/23/03
-   12832     3557 ; Fremont: Rte 84 @ Newark
-   12834     8323 ; Livermore: Airway @ Ruttan
-   12885     4075 ; Livermore: Portola @ P St.
-   12835     3147 ; Oakland: I-580 @ Fruitvale
-   12839     1700 ; Antioch: SR 4 @ Hillcrest
-   12840     8134 ; Walnut Creek: Mitchell @ Oak Grove
-   12841     2213 ; Herclues: I-80 @ Willow
-   12842     1720 ; Brentwood: Dainty @ Walnut
-   12886     1779 ; Danville: I-680 @ Sycamore Valley
-   12843     2283 ; Richmond: I-80 @ Hilltop
-   12883     8471 ; Healdsburg: Healdsburg and Grant Ave.
-   12844     7821 ; Mill Valley: Manzanitas Bus Pad
-   12844     7823 ; Mill Valley: Manzanitas Bus Pad
-   12880     7834 ; Mill Valley: Strawberry & Seminary
-   12880    20244 ; Mill Valley: Strawberry & Seminary
-   12871     8065 ; Novato: Atherton Bus Pad
-   12872     7982 ; Novato: Rowland Blvd
-;12845 	8189   ; Novato: Alameda del Prado Bus Pad
-   12845     7969 ; Novato: Alameda del Prado Bus Pad
-   16320     7891 ; San Rafael: Hetherton & Irwin
-   12847     7905 ; San Rafael: 4th and Heatherton
-   12847     7889 ; San Rafael: 4th and Heatherton
-   12848     7967 ; San Rafael: Lucas Valley Road Bus Pad
-;12848 	7955   ; San Rafael: Lucas Valley Road Bus Pad
-   12874     8201 ; Petaluma: Fairgrounds Drive
-   12882     8200 ; Petaluma: US 101 & Rte. 116 @ Lakeville
-   12849     8260 ; Cotati: US 101 @ Gravenstein
-   12881     8260 ; Cotati: Old Redwood Hwy @ St. Josephs
-   12851    20320 ; Rohnert Park: Roberts Lake and Golf Course Drive
-   12852     8526 ; Rohnert Park: Rohnert Park Expressway
-   12852     8418 ; Rohnert Park: Rohnert Park Expressway
-   12853     8407 ; Santa Rosa: Rte 12 @ Brookwood
-   12873     8369 ; Santa Rosa: GGT Piner & Industrial
-   12854     6691 ; Colma: D St. @ Junipero Serra Blvd.
-   12855     6465 ; Pacifica: Rte 1 @ Linda Mar
-   12856     6356 ; San Mateo: US 101 @ SR 92
-   12876     6082 ; Crystal Springs Reservoir: Hwy 92 @ Ralston
-   12877     6116 ; Redwood City: US 101 @ Whipple
-   12878     5894 ; Palo Alto: Oregon Expwy @ El Camino Real
-   12879     6718 ; Brisbane: Bayshore Blvd. @ Tunnel Ave.
-   12857     4299 ; Milpitas: Weller @ Main
-   12858     4295 ; San Jose: Almaden @ Camden
-   12859     4522 ; San Jose: Camden @ Branham
-   12859    12524 ; San Jose: Camden @ Branham
-   12860     4402 ; San Jose: Eastridge Mall
-   12884    11934 ; Dixon: B St. and Jefferson St.
-   12887    11430 ; Dixon: Merchant St.
-   12865    11926 ; Vallejo: Curtola @ Lemon
-   15902    11792 ; Vallejo: Waterfront Parking
-   12867    11789 ; Vacaville: Marshall @ Alamo
-   12875     8839 ; Vacaville: Davis St.
-   12868    11042 ; Fairfield: Solano Mall
-   12869    11870 ; Fairfield: Magellan Rd
-   12870    11040 ; Suisun: Florida @ Main
-   15731     2225 ; Hercules PNR
-   12838    11507 ; Richmond PNR: I-80 @ Richmond Parkway
-   12889     7807 ; Sausalito Spencer Ave. PNR
-   12889     7806 ; Sausalito Spencer Ave. PNR
-   16500     2146 ; Pacheco Blvd. Transit Hub
-   17000     8847 ; Vacaville Transportation Center
-   15989     2447 ; Oakley PNR
-   15999     8645 ; Trancas Intermodal
-   16010     1633 ; Pittsburg PNR
-   16015     1713 ; Byron PNR
-   16320     8109 ; Delong Ave. Bus Pad
-   16305     7969 ; Hamilton Theater PNR
-   16310     7869 ; Greenbrae PNR's
-   16315     7996 ; San Rafael: Lincoln & Prospect
-   16325     7852 ; Corte Madera: Redwood & Montecito PNR
-   17010    11631 ; Benicia Bus Hub
-   17020     2223 ; Hercules Transit Center
-   17030     7870 ; Greenbrae Sir Francis Drake Blvd at Drakes Lading Office Park
-   17035     7828 ; Mill Valley: Miller Ave at Evergreen Ave
-   17040     8239 ; Petaluma: South Petaluma Blvd at Hwy 101
+ 3807 12831 ; Fremont: Mission @ I-580  ** Service for 2000 RVAL00. SI. 8/23/03
+ 3557 12832 ; Fremont: Rte 84 @ Newark
+ 8323 12834 ; Livermore: Airway @ Ruttan
+ 4075 12885 ; Livermore: Portola @ P St.
+ 3147 12835 ; Oakland: I-580 @ Fruitvale
+ 1700 12839 ; Antioch: SR 4 @ Hillcrest
+ 8134 12840 ; Walnut Creek: Mitchell @ Oak Grove
+ 2213 12841 ; Herclues: I-80 @ Willow
+ 1720 12842 ; Brentwood: Dainty @ Walnut
+ 1779 12886 ; Danville: I-680 @ Sycamore Valley  
+ 2283 12843 ; Richmond: I-80 @ Hilltop
+ 8471 12883 ; Healdsburg: Healdsburg and Grant Ave.
+ 7821 12844 ; Mill Valley: Manzanitas Bus Pad
+ 7823 12844 ; Mill Valley: Manzanitas Bus Pad
+ 7834 12880 ; Mill Valley: Strawberry & Seminary
+20244 12880 ; Mill Valley: Strawberry & Seminary
+ 8065 12871 ; Novato: Atherton Bus Pad
+ 7982 12872 ; Novato: Rowland Blvd
+;8189 12845 ; Novato: Alameda del Prado Bus Pad
+ 7969 12845 ; Novato: Alameda del Prado Bus Pad
+ 7891 16320 ; San Rafael: Hetherton & Irwin
+ 7905 12847 ; San Rafael: 4th and Heatherton
+ 7889 12847 ; San Rafael: 4th and Heatherton
+ 7967 12848 ; San Rafael: Lucas Valley Road Bus Pad
+;7955 12848 ; San Rafael: Lucas Valley Road Bus Pad
+ 8201 12874 ; Petaluma: Fairgrounds Drive
+ 8200 12882 ; Petaluma: US 101 & Rte. 116 @ Lakeville
+ 8260 12849 ; Cotati: US 101 @ Gravenstein
+ 8260 12881 ; Cotati: Old Redwood Hwy @ St. Josephs
+20320 12851 ; Rohnert Park: Roberts Lake and Golf Course Drive
+ 8526 12852 ; Rohnert Park: Rohnert Park Expressway
+ 8418 12852 ; Rohnert Park: Rohnert Park Expressway
+ 8407 12853 ; Santa Rosa: Rte 12 @ Brookwood
+ 8369 12873 ; Santa Rosa: GGT Piner & Industrial
+ 6691 12854 ; Colma: D St. @ Junipero Serra Blvd.
+ 6465 12855 ; Pacifica: Rte 1 @ Linda Mar
+ 6356 12856 ; San Mateo: US 101 @ SR 92
+ 6082 12876 ; Crystal Springs Reservoir: Hwy 92 @ Ralston
+ 6116 12877 ; Redwood City: US 101 @ Whipple
+ 5894 12878 ; Palo Alto: Oregon Expwy @ El Camino Real
+ 6718 12879 ; Brisbane: Bayshore Blvd. @ Tunnel Ave.
+ 4299 12857 ; Milpitas: Weller @ Main
+ 4295 12858 ; San Jose: Almaden @ Camden
+ 4522 12859 ; San Jose: Camden @ Branham
+12524 12859 ; San Jose: Camden @ Branham
+ 4402 12860 ; San Jose: Eastridge Mall
+11934 12884 ; Dixon: B St. and Jefferson St.
+11430 12887 ; Dixon: Merchant St.
+11926 12865 ; Vallejo: Curtola @ Lemon
+11792 15902 ; Vallejo: Waterfront Parking
+11789 12867 ; Vacaville: Marshall @ Alamo
+ 8839 12875 ; Vacaville: Davis St.
+11042 12868 ; Fairfield: Solano Mall
+11870 12869 ; Fairfield: Magellan Rd
+11040 12870 ; Suisun: Florida @ Main
+ 2225 15731 ; Hercules PNR
+11507 12838 ; Richmond PNR: I-80 @ Richmond Parkway
+ 7807 12889 ; Sausalito Spencer Ave. PNR
+ 7806 12889 ; Sausalito Spencer Ave. PNR
+ 2146 16500 ; Pacheco Blvd. Transit Hub
+ 8847 17000 ; Vacaville Transportation Center
+ 2447 15989 ; Oakley PNR
+ 8645 15999 ; Trancas Intermodal
+ 1633 16010 ; Pittsburg PNR
+ 1713 16015 ; Byron PNR
+ 8109 16320 ; Delong Ave. Bus Pad
+ 7969 16305 ; Hamilton Theater PNR
+ 7869 16310 ; Greenbrae PNR's
+ 7996 16315 ; San Rafael: Lincoln & Prospect
+ 7852 16325 ; Corte Madera: Redwood & Montecito PNR
+11631 17010 ; Benicia Bus Hub
+ 2223 17020 ; Hercules Transit Center
+ 7870 17030 ; Greenbrae Sir Francis Drake Blvd at Drakes Lading Office Park
+ 7828 17035 ; Mill Valley: Miller Ave at Evergreen Ave
+ 8239 17040 ; Petaluma: South Petaluma Blvd at Hwy 101
 
 ;######################### From: M:\\Application\\Model One\\Networks\\TM1_2015_Base_Network\trn\transit_support\FERRY_neti_access_links.dat
 

--- a/trn/transitLines_express_bus.pnr
+++ b/trn/transitLines_express_bus.pnr
@@ -1,74 +1,74 @@
 
 ;######################### From: M:\\Application\\Model One\\Networks\\TM1_2015_Base_Network\trn\transit_support\express_bus.PNR
-
-PNR NODE=3807-12831 ZONES=1-1454 ; Fremont: Mission @ I-580
-PNR NODE=3557-12832 ZONES=1-1454 ; Fremont: Rte 84 @ Newark
-PNR NODE=8323-12834 ZONES=1-1454 ; Livermore: Airway @ Ruttan
-PNR NODE=4075-12885 ZONES=1-1454 ; Livermore: Portola @ P Street
-PNR NODE=3147-12835 ZONES=1-1454 ; Oakland: I-580 @ Fruitvale
-PNR NODE=1700-12839 ZONES=1-1454 ; Antioch: SR 4 @ Hillcrest
-PNR NODE=8134-12840 ZONES=1-1454 ; Walnut Creek: Mitchell @ Oak Grove
-PNR NODE=1779-12886 ZONES=1-1454 ; Danville: I-680 @ Sycamore Valley
-PNR NODE=2213-12841 ZONES=1-1454 ; Herclues: I-80 @ Willow
-PNR NODE=1720-12842 ZONES=1-1454 ; Brentwood: Dainty @ Walnut
-PNR NODE=11507-12838 ZONES=1-1454 ; Richmond: I-80 @ Richmond Parkway
-PNR NODE=2283-12843 ZONES=1-1454 ; Richmond: I-80 @ Hilltop
-PNR NODE=7821-12844 ZONES=1-1454 ; Mill Valley: Manzanitas Bus Pad
-PNR NODE=7823-12844 ZONES=1-1454 ; Mill Valley: Manzanitas Bus Pad
-PNR NODE=7834-12880 ZONES=1-1454 ; Mill Valley: Strawberry and Seminary
-PNR NODE=20244-12880 ZONES=1-1454 ; Mill Valley: Strawberry and Seminary
-PNR NODE=8065-12871 ZONES=1-1454 ; Novato: Atherton Bus Pad
-PNR NODE=7982-12872 ZONES=1-1454 ; Novato: Rowland Blvd
-PNR NODE=7969-12845 ZONES=1-1454 ; Novato: Alameda del Prado Bus Pad
-PNR NODE=7891-16320 ZONES=1-1454 ; San Rafael: Hetherton & Irwin
-PNR NODE=7905-12847 ZONES=1-1454 ; San Rafael: 4th and Heatherton
-PNR NODE=7889-12847 ZONES=1-1454 ; San Rafael: 4th and Heatherton
-PNR NODE=7967-12848 ZONES=1-1454 ; San Rafael: Lucas Valley Road Bus Pad
-PNR NODE=8201-12874 ZONES=1-1454 ; Petaluma: Fairgrounds Drive
-PNR NODE=8200-12882 ZONES=1-1454 ; Petaluma: US 101 @ 116 and Lakeville Street
-PNR NODE=8260-12849 ZONES=1-1454 ; Cotati: US 101 @ Gravenstein
-PNR NODE=8260-12881 ZONES=1-1454 ; Cotati: Old Redwood Highway & St. Josephs
-PNR NODE=8471-12883 ZONES=1-1454 ; Healdsburg: Healdsburg and Grant Avenue
-PNR NODE=20320-12851 ZONES=1-1454 ; Rohnert Park: Roberts Lake and Golf Course Drive
-PNR NODE=8526-12852 ZONES=1-1454 ; Rohnert Park: Rohnert Park Expressway
-PNR NODE=8418-12852 ZONES=1-1454 ; Rohnert Park: Rohnert Park Expressway
-PNR NODE=8407-12853 ZONES=1-1454 ; Santa Rosa: Rte 12 @ Brookwood
-PNR NODE=8369-12873 ZONES=1-1454 ; Santa Rosa: GGT Piner & Industrial
-PNR NODE=6691-12854 ZONES=1-1454 ; Colma: D St. @ Junipero Serra Blvd.
-PNR NODE=6465-12855 ZONES=1-1454 ; Pacifica: Rte 1 @ Linda Mar
-PNR NODE=6356-12856 ZONES=1-1454 ; San Mateo: US 101 @ SR 92
-PNR NODE=6082-12876 ZONES=1-1454 ; Crystal Springs Reservoir: Hwy 92 @ Ralston
-PNR NODE=6116-12877 ZONES=1-1454 ; Redwood City: US 101 @ Whipple
-PNR NODE=5894-12878 ZONES=1-1454 ; Palo Alto: Oregon Expwy @ El Camino Real
-PNR NODE=6718-12879 ZONES=1-1454 ; Brisbane: Bayshore Blvd. @ Tunnel Ave.
-PNR NODE=4299-12857 ZONES=1-1454 ; Milpitas: Weller @ Main
-PNR NODE=4295-12858 ZONES=1-1454 ; San Jose: Almaden @ Camden
-PNR NODE=4522-12859 ZONES=1-1454 ; San Jose: Camden @ Branham
-PNR NODE=4402-12860 ZONES=1-1454 ; San Jose: Eastridge Mall
-PNR NODE=11926-12865 ZONES=1-1454 ; Vallejo: Curtola @ Lemon
-PNR NODE=11792-15902 ZONES=1-1454 ; Vallejo: Waterfront Parking
-PNR NODE=8839-12875 ZONES=1-1454 ; Vacaville: Davis Steet PNR
-PNR NODE=11042-12868 ZONES=1-1454 ; Fairfield: Solano Mall
-PNR NODE=11870-12869 ZONES=1-1454 ; Fairfield: Magellan Rd
-PNR NODE=11040-12870 ZONES=1-1454 ; Suisun: Florida @ Main
-PNR NODE=11934-12884 ZONES=1-1454 ; Dixon: B Street @ Jefferson
-PNR NODE=2225-15731 ZONES=1-1454 ; Hercules: San Pablo, Sycamore & John Muir Pkwy
-PNR NODE=11430-12887 ZONES=1-1454 ; Dixon: Merchant St.
-PNR NODE=7806-12889 ZONES=1-1454 ; Sausalito Spencer Ave. PNR
-PNR NODE=7807-12889 ZONES=1-1454 ;PNR NODE=2146-15969 ZONES=1-1454	; Pacheco Blvd. Transit Hub PNR
-PNR NODE=8847-17000 ZONES=1-1454 ; Vacaville Transportation Center PNR
-PNR NODE=2447-15989 ZONES=1-1454 ; Oakley
-PNR NODE=8645-15999 ZONES=1-1454 ; Redwood PNR
-PNR NODE=1633-16010 ZONES=1-1454 ; Pittsburg PNR
-PNR NODE=1713-16015 ZONES=1-1454 ; Byron PNR
-PNR NODE=8109-16300 ZONES=1-1454 ; Delong Bus Pad
-PNR NODE=7969-16305 ZONES=1-1454 ; Hamilton Theater PNR
-PNR NODE=7996-16315 ZONES=1-1454 ; San Rafael: Lincoln & Prospect
-PNR NODE=7869-16310 ZONES=1-1454 ; Greenbrae PNR's
-PNR NODE=7852-16325 ZONES=1-1454 ; Corte Madera: Redwwod & Montecito PNR
-PNR NODE=2146-16500 ZONES=1-1454 ; Pacheco Transit Hub
-PNR NODE=11631-17010 ZONES=1-1454 ; Benicia Bus Hub
-PNR NODE=2223-17020 ZONES=1-1454 ; Hercules Transit Center
-PNR NODE=7870-17030 ZONES=1-1454 ; Greenbrae Sir Francis Drake Blvd at Drakes Lading Office Park
-PNR NODE=7828-17035 ZONES=1-1454 ; Mill Valley: Miller Ave at Evergreen Ave
-PNR NODE=8239-17040 ZONES=1-1454 ; Petaluma: South Petaluma Blvd at Hwy 101
+PNR NODE=12831-3807 ZONES=1-1454	; Fremont: Mission @ I-580
+PNR NODE=12832-3557 ZONES=1-1454	; Fremont: Rte 84 @ Newark
+PNR NODE=12834-8323 ZONES=1-1454	; Livermore: Airway @ Ruttan
+PNR NODE=12885-4075 ZONES=1-1454	; Livermore: Portola @ P Street
+PNR NODE=12835-3147 ZONES=1-1454	; Oakland: I-580 @ Fruitvale
+PNR NODE=12839-1700 ZONES=1-1454	; Antioch: SR 4 @ Hillcrest
+PNR NODE=12840-8134 ZONES=1-1454	; Walnut Creek: Mitchell @ Oak Grove
+PNR NODE=12886-1779 ZONES=1-1454	; Danville: I-680 @ Sycamore Valley
+PNR NODE=12841-2213 ZONES=1-1454	; Herclues: I-80 @ Willow
+PNR NODE=12842-1720 ZONES=1-1454	; Brentwood: Dainty @ Walnut
+PNR NODE=12838-11507 ZONES=1-1454	; Richmond: I-80 @ Richmond Parkway
+PNR NODE=12843-2283 ZONES=1-1454	; Richmond: I-80 @ Hilltop
+PNR NODE=12844-7821 ZONES=1-1454	; Mill Valley: Manzanitas Bus Pad
+PNR NODE=12844-7823 ZONES=1-1454	; Mill Valley: Manzanitas Bus Pad
+PNR NODE=12880-7834 ZONES=1-1454	; Mill Valley: Strawberry and Seminary
+PNR NODE=12880-20244 ZONES=1-1454	; Mill Valley: Strawberry and Seminary
+PNR NODE=12871-8065 ZONES=1-1454	; Novato: Atherton Bus Pad
+PNR NODE=12872-7982 ZONES=1-1454	; Novato: Rowland Blvd
+PNR NODE=12845-7969 ZONES=1-1454	; Novato: Alameda del Prado Bus Pad
+PNR NODE=16320-7891 ZONES=1-1454	; San Rafael: Hetherton & Irwin 
+PNR NODE=12847-7905 ZONES=1-1454	; San Rafael: 4th and Heatherton
+PNR NODE=12847-7889 ZONES=1-1454	; San Rafael: 4th and Heatherton
+PNR NODE=12848-7967 ZONES=1-1454    ; San Rafael: Lucas Valley Road Bus Pad         
+PNR NODE=12874-8201 ZONES=1-1454	; Petaluma: Fairgrounds Drive
+PNR NODE=12882-8200 ZONES=1-1454	; Petaluma: US 101 @ 116 and Lakeville Street
+PNR NODE=12849-8260 ZONES=1-1454	; Cotati: US 101 @ Gravenstein
+PNR NODE=12881-8260 ZONES=1-1454	; Cotati: Old Redwood Highway & St. Josephs
+PNR NODE=12883-8471 ZONES=1-1454	; Healdsburg: Healdsburg and Grant Avenue
+PNR NODE=12851-20320 ZONES=1-1454	; Rohnert Park: Roberts Lake and Golf Course Drive
+PNR NODE=12852-8526 ZONES=1-1454	; Rohnert Park: Rohnert Park Expressway
+PNR NODE=12852-8418 ZONES=1-1454	; Rohnert Park: Rohnert Park Expressway
+PNR NODE=12853-8407 ZONES=1-1454	; Santa Rosa: Rte 12 @ Brookwood
+PNR NODE=12873-8369 ZONES=1-1454	; Santa Rosa: GGT Piner & Industrial
+PNR NODE=12854-6691 ZONES=1-1454	; Colma: D St. @ Junipero Serra Blvd.
+PNR NODE=12855-6465 ZONES=1-1454	; Pacifica: Rte 1 @ Linda Mar
+PNR NODE=12856-6356 ZONES=1-1454	; San Mateo: US 101 @ SR 92
+PNR NODE=12876-6082 ZONES=1-1454	; Crystal Springs Reservoir: Hwy 92 @ Ralston
+PNR NODE=12877-6116 ZONES=1-1454	; Redwood City: US 101 @ Whipple
+PNR NODE=12878-5894 ZONES=1-1454	; Palo Alto: Oregon Expwy @ El Camino Real
+PNR NODE=12879-6718 ZONES=1-1454	; Brisbane: Bayshore Blvd. @ Tunnel Ave.
+PNR NODE=12857-4299 ZONES=1-1454	; Milpitas: Weller @ Main
+PNR NODE=12858-4295 ZONES=1-1454	; San Jose: Almaden @ Camden
+PNR NODE=12859-4522 ZONES=1-1454	; San Jose: Camden @ Branham
+PNR NODE=12860-4402 ZONES=1-1454	; San Jose: Eastridge Mall
+PNR NODE=12865-11926 ZONES=1-1454	; Vallejo: Curtola @ Lemon
+PNR NODE=15902-11792 ZONES=1-1454	; Vallejo: Waterfront Parking
+PNR NODE=12875-8839 ZONES=1-1454	; Vacaville: Davis Steet PNR
+PNR NODE=12868-11042 ZONES=1-1454	; Fairfield: Solano Mall
+PNR NODE=12869-11870 ZONES=1-1454	; Fairfield: Magellan Rd
+PNR NODE=12870-11040 ZONES=1-1454	; Suisun: Florida @ Main
+PNR NODE=12884-11934 ZONES=1-1454	; Dixon: B Street @ Jefferson
+PNR NODE=15731-2225 ZONES=1-1454	; Hercules: San Pablo, Sycamore & John Muir Pkwy
+PNR NODE=12887-11430 ZONES=1-1454	; Dixon: Merchant St.
+PNR NODE=12889-7806 ZONES=1-1454	; Sausalito Spencer Ave. PNR
+PNR NODE=12889-7807 ZONES=1-1454	; Sausalito Spencer Ave. PNR
+;PNR NODE=15969-2146 ZONES=1-1454	; Pacheco Blvd. Transit Hub PNR
+PNR NODE=17000-8847 ZONES=1-1454	; Vacaville Transportation Center PNR
+PNR NODE=15989-2447 ZONES=1-1454	; Oakley
+PNR NODE=15999-8645 ZONES=1-1454	; Redwood PNR
+PNR NODE=16010-1633 ZONES=1-1454	; Pittsburg PNR
+PNR NODE=16015-1713 ZONES=1-1454	; Byron PNR
+PNR NODE=16300-8109 ZONES=1-1454	; Delong Bus Pad
+PNR NODE=16305-7969 ZONES=1-1454	; Hamilton Theater PNR
+PNR NODE=16315-7996 ZONES=1-1454	; San Rafael: Lincoln & Prospect
+PNR NODE=16310-7869 ZONES=1-1454	; Greenbrae PNR's
+PNR NODE=16325-7852 ZONES=1-1454	; Corte Madera: Redwwod & Montecito PNR
+PNR NODE=16500-2146 ZONES=1-1454    ; Pacheco Transit Hub
+PNR NODE=17010-11631 ZONES=1-1454   ; Benicia Bus Hub
+PNR NODE=17020-2223 ZONES=1-1454    ; Hercules Transit Center
+PNR NODE=17030-7870 ZONES=1-1454    ; Greenbrae Sir Francis Drake Blvd at Drakes Lading Office Park
+PNR NODE=17035-7828 ZONES=1-1454    ; Mill Valley: Miller Ave at Evergreen Ave
+PNR NODE=17040-8239 ZONES=1-1454    ; Petaluma: South Petaluma Blvd at Hwy 101

--- a/trn/transit_support/express_bus.PNR
+++ b/trn/transit_support/express_bus.PNR
@@ -4,76 +4,76 @@
 ; Read Bus PNR's*
 ;****************
 
-PNR NODE=3807-12831 ZONES=1-1454	; Fremont: Mission @ I-580
-PNR NODE=3557-12832 ZONES=1-1454	; Fremont: Rte 84 @ Newark
-PNR NODE=8323-12834 ZONES=1-1454	; Livermore: Airway @ Ruttan
-PNR NODE=4075-12885 ZONES=1-1454	; Livermore: Portola @ P Street
-PNR NODE=3147-12835 ZONES=1-1454	; Oakland: I-580 @ Fruitvale
-PNR NODE=1700-12839 ZONES=1-1454	; Antioch: SR 4 @ Hillcrest
-PNR NODE=8134-12840 ZONES=1-1454	; Walnut Creek: Mitchell @ Oak Grove
-PNR NODE=1779-12886 ZONES=1-1454	; Danville: I-680 @ Sycamore Valley
-PNR NODE=2213-12841 ZONES=1-1454	; Herclues: I-80 @ Willow
-PNR NODE=1720-12842 ZONES=1-1454	; Brentwood: Dainty @ Walnut
-PNR NODE=11507-12838 ZONES=1-1454	; Richmond: I-80 @ Richmond Parkway
-PNR NODE=2283-12843 ZONES=1-1454	; Richmond: I-80 @ Hilltop
-PNR NODE=7821-12844 ZONES=1-1454	; Mill Valley: Manzanitas Bus Pad
-PNR NODE=7823-12844 ZONES=1-1454	; Mill Valley: Manzanitas Bus Pad
-PNR NODE=7834-12880 ZONES=1-1454	; Mill Valley: Strawberry and Seminary
-PNR NODE=20244-12880 ZONES=1-1454	; Mill Valley: Strawberry and Seminary
-PNR NODE=8065-12871 ZONES=1-1454	; Novato: Atherton Bus Pad
-PNR NODE=7982-12872 ZONES=1-1454	; Novato: Rowland Blvd
-PNR NODE=7969-12845 ZONES=1-1454	; Novato: Alameda del Prado Bus Pad
-PNR NODE=7891-16320 ZONES=1-1454	; San Rafael: Hetherton & Irwin 
-PNR NODE=7905-12847 ZONES=1-1454	; San Rafael: 4th and Heatherton
-PNR NODE=7889-12847 ZONES=1-1454	; San Rafael: 4th and Heatherton
-PNR NODE=7967-12848 ZONES=1-1454        ; San Rafael: Lucas Valley Road Bus Pad         
-PNR NODE=8201-12874 ZONES=1-1454	; Petaluma: Fairgrounds Drive
-PNR NODE=8200-12882 ZONES=1-1454	; Petaluma: US 101 @ 116 and Lakeville Street
-PNR NODE=8260-12849 ZONES=1-1454	; Cotati: US 101 @ Gravenstein
-PNR NODE=8260-12881 ZONES=1-1454	; Cotati: Old Redwood Highway & St. Josephs
-PNR NODE=8471-12883 ZONES=1-1454	; Healdsburg: Healdsburg and Grant Avenue
-PNR NODE=20320-12851 ZONES=1-1454	; Rohnert Park: Roberts Lake and Golf Course Drive
-PNR NODE=8526-12852 ZONES=1-1454	; Rohnert Park: Rohnert Park Expressway
-PNR NODE=8418-12852 ZONES=1-1454	; Rohnert Park: Rohnert Park Expressway
-PNR NODE=8407-12853 ZONES=1-1454	; Santa Rosa: Rte 12 @ Brookwood
-PNR NODE=8369-12873 ZONES=1-1454	; Santa Rosa: GGT Piner & Industrial
-PNR NODE=6691-12854 ZONES=1-1454	; Colma: D St. @ Junipero Serra Blvd.
-PNR NODE=6465-12855 ZONES=1-1454	; Pacifica: Rte 1 @ Linda Mar
-PNR NODE=6356-12856 ZONES=1-1454	; San Mateo: US 101 @ SR 92
-PNR NODE=6082-12876 ZONES=1-1454	; Crystal Springs Reservoir: Hwy 92 @ Ralston
-PNR NODE=6116-12877 ZONES=1-1454	; Redwood City: US 101 @ Whipple
-PNR NODE=5894-12878 ZONES=1-1454	; Palo Alto: Oregon Expwy @ El Camino Real
-PNR NODE=6718-12879 ZONES=1-1454	; Brisbane: Bayshore Blvd. @ Tunnel Ave.
-PNR NODE=4299-12857 ZONES=1-1454	; Milpitas: Weller @ Main
-PNR NODE=4295-12858 ZONES=1-1454	; San Jose: Almaden @ Camden
-PNR NODE=4522-12859 ZONES=1-1454	; San Jose: Camden @ Branham
-PNR NODE=4402-12860 ZONES=1-1454	; San Jose: Eastridge Mall
-PNR NODE=11926-12865 ZONES=1-1454	; Vallejo: Curtola @ Lemon
-PNR NODE=11792-15902 ZONES=1-1454	; Vallejo: Waterfront Parking
-PNR NODE=8839-12875 ZONES=1-1454	; Vacaville: Davis Steet PNR
-PNR NODE=11042-12868 ZONES=1-1454	; Fairfield: Solano Mall
-PNR NODE=11870-12869 ZONES=1-1454	; Fairfield: Magellan Rd
-PNR NODE=11040-12870 ZONES=1-1454	; Suisun: Florida @ Main
-PNR NODE=11934-12884 ZONES=1-1454	; Dixon: B Street @ Jefferson
-PNR NODE=2225-15731 ZONES=1-1454	; Hercules: San Pablo, Sycamore & John Muir Pkwy
-PNR NODE=11430-12887 ZONES=1-1454	; Dixon: Merchant St.
-PNR NODE=7806-12889 ZONES=1-1454	; Sausalito Spencer Ave. PNR
-PNR NODE=7807-12889 ZONES=1-1454	; Sausalito Spencer Ave. PNR
-;PNR NODE=2146-15969 ZONES=1-1454	; Pacheco Blvd. Transit Hub PNR
-PNR NODE=8847-17000 ZONES=1-1454	; Vacaville Transportation Center PNR
-PNR NODE=2447-15989 ZONES=1-1454	; Oakley
-PNR NODE=8645-15999 ZONES=1-1454	; Redwood PNR
-PNR NODE=1633-16010 ZONES=1-1454	; Pittsburg PNR
-PNR NODE=1713-16015 ZONES=1-1454	; Byron PNR
-PNR NODE=8109-16300 ZONES=1-1454	; Delong Bus Pad
-PNR NODE=7969-16305 ZONES=1-1454	; Hamilton Theater PNR
-PNR NODE=7996-16315 ZONES=1-1454	; San Rafael: Lincoln & Prospect
-PNR NODE=7869-16310 ZONES=1-1454	; Greenbrae PNR's
-PNR NODE=7852-16325 ZONES=1-1454	; Corte Madera: Redwwod & Montecito PNR
-PNR NODE=2146-16500 ZONES=1-1454        ; Pacheco Transit Hub
-PNR NODE=11631-17010 ZONES=1-1454        ; Benicia Bus Hub
-PNR NODE=2223-17020 ZONES=1-1454        ; Hercules Transit Center
-PNR NODE=7870-17030 ZONES=1-1454        ; Greenbrae Sir Francis Drake Blvd at Drakes Lading Office Park
-PNR NODE=7828-17035 ZONES=1-1454        ; Mill Valley: Miller Ave at Evergreen Ave
-PNR NODE=8239-17040 ZONES=1-1454        ; Petaluma: South Petaluma Blvd at Hwy 101
+PNR NODE=12831-3807 ZONES=1-1454	; Fremont: Mission @ I-580
+PNR NODE=12832-3557 ZONES=1-1454	; Fremont: Rte 84 @ Newark
+PNR NODE=12834-8323 ZONES=1-1454	; Livermore: Airway @ Ruttan
+PNR NODE=12885-4075 ZONES=1-1454	; Livermore: Portola @ P Street
+PNR NODE=12835-3147 ZONES=1-1454	; Oakland: I-580 @ Fruitvale
+PNR NODE=12839-1700 ZONES=1-1454	; Antioch: SR 4 @ Hillcrest
+PNR NODE=12840-8134 ZONES=1-1454	; Walnut Creek: Mitchell @ Oak Grove
+PNR NODE=12886-1779 ZONES=1-1454	; Danville: I-680 @ Sycamore Valley
+PNR NODE=12841-2213 ZONES=1-1454	; Herclues: I-80 @ Willow
+PNR NODE=12842-1720 ZONES=1-1454	; Brentwood: Dainty @ Walnut
+PNR NODE=12838-11507 ZONES=1-1454	; Richmond: I-80 @ Richmond Parkway
+PNR NODE=12843-2283 ZONES=1-1454	; Richmond: I-80 @ Hilltop
+PNR NODE=12844-7821 ZONES=1-1454	; Mill Valley: Manzanitas Bus Pad
+PNR NODE=12844-7823 ZONES=1-1454	; Mill Valley: Manzanitas Bus Pad
+PNR NODE=12880-7834 ZONES=1-1454	; Mill Valley: Strawberry and Seminary
+PNR NODE=12880-20244 ZONES=1-1454	; Mill Valley: Strawberry and Seminary
+PNR NODE=12871-8065 ZONES=1-1454	; Novato: Atherton Bus Pad
+PNR NODE=12872-7982 ZONES=1-1454	; Novato: Rowland Blvd
+PNR NODE=12845-7969 ZONES=1-1454	; Novato: Alameda del Prado Bus Pad
+PNR NODE=16320-7891 ZONES=1-1454	; San Rafael: Hetherton & Irwin 
+PNR NODE=12847-7905 ZONES=1-1454	; San Rafael: 4th and Heatherton
+PNR NODE=12847-7889 ZONES=1-1454	; San Rafael: 4th and Heatherton
+PNR NODE=12848-7967 ZONES=1-1454    ; San Rafael: Lucas Valley Road Bus Pad         
+PNR NODE=12874-8201 ZONES=1-1454	; Petaluma: Fairgrounds Drive
+PNR NODE=12882-8200 ZONES=1-1454	; Petaluma: US 101 @ 116 and Lakeville Street
+PNR NODE=12849-8260 ZONES=1-1454	; Cotati: US 101 @ Gravenstein
+PNR NODE=12881-8260 ZONES=1-1454	; Cotati: Old Redwood Highway & St. Josephs
+PNR NODE=12883-8471 ZONES=1-1454	; Healdsburg: Healdsburg and Grant Avenue
+PNR NODE=12851-20320 ZONES=1-1454	; Rohnert Park: Roberts Lake and Golf Course Drive
+PNR NODE=12852-8526 ZONES=1-1454	; Rohnert Park: Rohnert Park Expressway
+PNR NODE=12852-8418 ZONES=1-1454	; Rohnert Park: Rohnert Park Expressway
+PNR NODE=12853-8407 ZONES=1-1454	; Santa Rosa: Rte 12 @ Brookwood
+PNR NODE=12873-8369 ZONES=1-1454	; Santa Rosa: GGT Piner & Industrial
+PNR NODE=12854-6691 ZONES=1-1454	; Colma: D St. @ Junipero Serra Blvd.
+PNR NODE=12855-6465 ZONES=1-1454	; Pacifica: Rte 1 @ Linda Mar
+PNR NODE=12856-6356 ZONES=1-1454	; San Mateo: US 101 @ SR 92
+PNR NODE=12876-6082 ZONES=1-1454	; Crystal Springs Reservoir: Hwy 92 @ Ralston
+PNR NODE=12877-6116 ZONES=1-1454	; Redwood City: US 101 @ Whipple
+PNR NODE=12878-5894 ZONES=1-1454	; Palo Alto: Oregon Expwy @ El Camino Real
+PNR NODE=12879-6718 ZONES=1-1454	; Brisbane: Bayshore Blvd. @ Tunnel Ave.
+PNR NODE=12857-4299 ZONES=1-1454	; Milpitas: Weller @ Main
+PNR NODE=12858-4295 ZONES=1-1454	; San Jose: Almaden @ Camden
+PNR NODE=12859-4522 ZONES=1-1454	; San Jose: Camden @ Branham
+PNR NODE=12860-4402 ZONES=1-1454	; San Jose: Eastridge Mall
+PNR NODE=12865-11926 ZONES=1-1454	; Vallejo: Curtola @ Lemon
+PNR NODE=15902-11792 ZONES=1-1454	; Vallejo: Waterfront Parking
+PNR NODE=12875-8839 ZONES=1-1454	; Vacaville: Davis Steet PNR
+PNR NODE=12868-11042 ZONES=1-1454	; Fairfield: Solano Mall
+PNR NODE=12869-11870 ZONES=1-1454	; Fairfield: Magellan Rd
+PNR NODE=12870-11040 ZONES=1-1454	; Suisun: Florida @ Main
+PNR NODE=12884-11934 ZONES=1-1454	; Dixon: B Street @ Jefferson
+PNR NODE=15731-2225 ZONES=1-1454	; Hercules: San Pablo, Sycamore & John Muir Pkwy
+PNR NODE=12887-11430 ZONES=1-1454	; Dixon: Merchant St.
+PNR NODE=12889-7806 ZONES=1-1454	; Sausalito Spencer Ave. PNR
+PNR NODE=12889-7807 ZONES=1-1454	; Sausalito Spencer Ave. PNR
+;PNR NODE=15969-2146 ZONES=1-1454	; Pacheco Blvd. Transit Hub PNR
+PNR NODE=17000-8847 ZONES=1-1454	; Vacaville Transportation Center PNR
+PNR NODE=15989-2447 ZONES=1-1454	; Oakley
+PNR NODE=15999-8645 ZONES=1-1454	; Redwood PNR
+PNR NODE=16010-1633 ZONES=1-1454	; Pittsburg PNR
+PNR NODE=16015-1713 ZONES=1-1454	; Byron PNR
+PNR NODE=16300-8109 ZONES=1-1454	; Delong Bus Pad
+PNR NODE=16305-7969 ZONES=1-1454	; Hamilton Theater PNR
+PNR NODE=16315-7996 ZONES=1-1454	; San Rafael: Lincoln & Prospect
+PNR NODE=16310-7869 ZONES=1-1454	; Greenbrae PNR's
+PNR NODE=16325-7852 ZONES=1-1454	; Corte Madera: Redwwod & Montecito PNR
+PNR NODE=16500-2146 ZONES=1-1454    ; Pacheco Transit Hub
+PNR NODE=17010-11631 ZONES=1-1454   ; Benicia Bus Hub
+PNR NODE=17020-2223 ZONES=1-1454    ; Hercules Transit Center
+PNR NODE=17030-7870 ZONES=1-1454    ; Greenbrae Sir Francis Drake Blvd at Drakes Lading Office Park
+PNR NODE=17035-7828 ZONES=1-1454    ; Mill Valley: Miller Ave at Evergreen Ave
+PNR NODE=17040-8239 ZONES=1-1454    ; Petaluma: South Petaluma Blvd at Hwy 101
 

--- a/trn/transit_support/express_bus_neti_access_links.dat
+++ b/trn/transit_support/express_bus_neti_access_links.dat
@@ -1,89 +1,77 @@
-;
 ;  Access Nodes to Bus Pads (the next Bus Pads were not coded as PNR)
-;
-;  Ignacio Blvd: 7988, 11479
-;  Marinwood (Miller Creek): 7966, 7965
-;  Terra Linda: 7946, 7944
-;  N. San Pedro Rd.: 7933, 7932
-;  Lucky Drive: 8177, 7871
-;  Paradise Drive: 7850, 7860
-;  Tiburon Wye: 7841, 78444
-;
-;  Reviewed on 1/13/11 by BE
-;
 
-12831 	3807   ; Fremont: Mission @ I-580  ** Service for 2000 RVAL00. SI. 8/23/03
-12832 	3557   ; Fremont: Rte 84 @ Newark
-12834 	8323   ; Livermore: Airway @ Ruttan
-12885 	4075   ; Livermore: Portola @ P St.
-12835 	3147   ; Oakland: I-580 @ Fruitvale
-12839 	1700   ; Antioch: SR 4 @ Hillcrest
-12840 	8134   ; Walnut Creek: Mitchell @ Oak Grove
-12841 	2213   ; Herclues: I-80 @ Willow
-12842 	1720   ; Brentwood: Dainty @ Walnut
-12886 	1779   ; Danville: I-680 @ Sycamore Valley  
-12843 	2283   ; Richmond: I-80 @ Hilltop
-12883 	8471   ; Healdsburg: Healdsburg and Grant Ave.
-12844 	7821   ; Mill Valley: Manzanitas Bus Pad
-12844 	7823   ; Mill Valley: Manzanitas Bus Pad
-12880 	7834   ; Mill Valley: Strawberry & Seminary
-12880  20244   ; Mill Valley: Strawberry & Seminary
-12871 	8065   ; Novato: Atherton Bus Pad
-12872 	7982   ; Novato: Rowland Blvd
-;12845 	8189   ; Novato: Alameda del Prado Bus Pad
-12845 	7969   ; Novato: Alameda del Prado Bus Pad
-16320 	7891   ; San Rafael: Hetherton & Irwin
-12847 	7905   ; San Rafael: 4th and Heatherton
-12847 	7889   ; San Rafael: 4th and Heatherton
-12848 	7967   ; San Rafael: Lucas Valley Road Bus Pad
-;12848 	7955   ; San Rafael: Lucas Valley Road Bus Pad
-12874 	8201   ; Petaluma: Fairgrounds Drive
-12882 	8200   ; Petaluma: US 101 & Rte. 116 @ Lakeville
-12849 	8260   ; Cotati: US 101 @ Gravenstein
-12881 	8260   ; Cotati: Old Redwood Hwy @ St. Josephs
-12851  20320   ; Rohnert Park: Roberts Lake and Golf Course Drive
-12852 	8526   ; Rohnert Park: Rohnert Park Expressway
-12852 	8418   ; Rohnert Park: Rohnert Park Expressway
-12853 	8407   ; Santa Rosa: Rte 12 @ Brookwood
-12873 	8369   ; Santa Rosa: GGT Piner & Industrial
-12854 	6691   ; Colma: D St. @ Junipero Serra Blvd.
-12855 	6465   ; Pacifica: Rte 1 @ Linda Mar
-12856 	6356   ; San Mateo: US 101 @ SR 92
-12876 	6082   ; Crystal Springs Reservoir: Hwy 92 @ Ralston
-12877 	6116   ; Redwood City: US 101 @ Whipple
-12878 	5894   ; Palo Alto: Oregon Expwy @ El Camino Real
-12879 	6718   ; Brisbane: Bayshore Blvd. @ Tunnel Ave.
-12857 	4299   ; Milpitas: Weller @ Main
-12858 	4295   ; San Jose: Almaden @ Camden
-12859 	4522   ; San Jose: Camden @ Branham
-12859	12524  ; San Jose: Camden @ Branham
-12860 	4402   ; San Jose: Eastridge Mall
-12884	11934  ; Dixon: B St. and Jefferson St.
-12887   11430  ; Dixon: Merchant St.
-12865	11926   ; Vallejo: Curtola @ Lemon
-15902   11792   ; Vallejo: Waterfront Parking
-12867	11789   ; Vacaville: Marshall @ Alamo
-12875 	8839   ; Vacaville: Davis St.
-12868	11042  ; Fairfield: Solano Mall
-12869	11870   ; Fairfield: Magellan Rd
-12870	11040  ; Suisun: Florida @ Main
-15731 	2225   ; Hercules PNR
-12838	11507  ; Richmond PNR: I-80 @ Richmond Parkway
-12889   7807   ; Sausalito Spencer Ave. PNR
-12889   7806   ; Sausalito Spencer Ave. PNR
-16500   2146   ; Pacheco Blvd. Transit Hub
-17000   8847   ; Vacaville Transportation Center
-15989   2447   ; Oakley PNR
-15999   8645   ; Trancas Intermodal
-16010   1633   ; Pittsburg PNR
-16015   1713   ; Byron PNR
-16320   8109   ; Delong Ave. Bus Pad
-16305   7969   ; Hamilton Theater PNR
-16310   7869   ; Greenbrae PNR's
-16315   7996   ; San Rafael: Lincoln & Prospect
-16325   7852   ; Corte Madera: Redwood & Montecito PNR
-17010  11631   ; Benicia Bus Hub
-17020   2223   ; Hercules Transit Center
-17030   7870   ; Greenbrae Sir Francis Drake Blvd at Drakes Lading Office Park
-17035   7828   ; Mill Valley: Miller Ave at Evergreen Ave
-17040   8239   ; Petaluma: South Petaluma Blvd at Hwy 101
+ 3807 12831 ; Fremont: Mission @ I-580  ** Service for 2000 RVAL00. SI. 8/23/03
+ 3557 12832 ; Fremont: Rte 84 @ Newark
+ 8323 12834 ; Livermore: Airway @ Ruttan
+ 4075 12885 ; Livermore: Portola @ P St.
+ 3147 12835 ; Oakland: I-580 @ Fruitvale
+ 1700 12839 ; Antioch: SR 4 @ Hillcrest
+ 8134 12840 ; Walnut Creek: Mitchell @ Oak Grove
+ 2213 12841 ; Herclues: I-80 @ Willow
+ 1720 12842 ; Brentwood: Dainty @ Walnut
+ 1779 12886 ; Danville: I-680 @ Sycamore Valley  
+ 2283 12843 ; Richmond: I-80 @ Hilltop
+ 8471 12883 ; Healdsburg: Healdsburg and Grant Ave.
+ 7821 12844 ; Mill Valley: Manzanitas Bus Pad
+ 7823 12844 ; Mill Valley: Manzanitas Bus Pad
+ 7834 12880 ; Mill Valley: Strawberry & Seminary
+20244 12880 ; Mill Valley: Strawberry & Seminary
+ 8065 12871 ; Novato: Atherton Bus Pad
+ 7982 12872 ; Novato: Rowland Blvd
+;8189 12845 ; Novato: Alameda del Prado Bus Pad
+ 7969 12845 ; Novato: Alameda del Prado Bus Pad
+ 7891 16320 ; San Rafael: Hetherton & Irwin
+ 7905 12847 ; San Rafael: 4th and Heatherton
+ 7889 12847 ; San Rafael: 4th and Heatherton
+ 7967 12848 ; San Rafael: Lucas Valley Road Bus Pad
+;7955 12848 ; San Rafael: Lucas Valley Road Bus Pad
+ 8201 12874 ; Petaluma: Fairgrounds Drive
+ 8200 12882 ; Petaluma: US 101 & Rte. 116 @ Lakeville
+ 8260 12849 ; Cotati: US 101 @ Gravenstein
+ 8260 12881 ; Cotati: Old Redwood Hwy @ St. Josephs
+20320 12851 ; Rohnert Park: Roberts Lake and Golf Course Drive
+ 8526 12852 ; Rohnert Park: Rohnert Park Expressway
+ 8418 12852 ; Rohnert Park: Rohnert Park Expressway
+ 8407 12853 ; Santa Rosa: Rte 12 @ Brookwood
+ 8369 12873 ; Santa Rosa: GGT Piner & Industrial
+ 6691 12854 ; Colma: D St. @ Junipero Serra Blvd.
+ 6465 12855 ; Pacifica: Rte 1 @ Linda Mar
+ 6356 12856 ; San Mateo: US 101 @ SR 92
+ 6082 12876 ; Crystal Springs Reservoir: Hwy 92 @ Ralston
+ 6116 12877 ; Redwood City: US 101 @ Whipple
+ 5894 12878 ; Palo Alto: Oregon Expwy @ El Camino Real
+ 6718 12879 ; Brisbane: Bayshore Blvd. @ Tunnel Ave.
+ 4299 12857 ; Milpitas: Weller @ Main
+ 4295 12858 ; San Jose: Almaden @ Camden
+ 4522 12859 ; San Jose: Camden @ Branham
+12524 12859 ; San Jose: Camden @ Branham
+ 4402 12860 ; San Jose: Eastridge Mall
+11934 12884 ; Dixon: B St. and Jefferson St.
+11430 12887 ; Dixon: Merchant St.
+11926 12865 ; Vallejo: Curtola @ Lemon
+11792 15902 ; Vallejo: Waterfront Parking
+11789 12867 ; Vacaville: Marshall @ Alamo
+ 8839 12875 ; Vacaville: Davis St.
+11042 12868 ; Fairfield: Solano Mall
+11870 12869 ; Fairfield: Magellan Rd
+11040 12870 ; Suisun: Florida @ Main
+ 2225 15731 ; Hercules PNR
+11507 12838 ; Richmond PNR: I-80 @ Richmond Parkway
+ 7807 12889 ; Sausalito Spencer Ave. PNR
+ 7806 12889 ; Sausalito Spencer Ave. PNR
+ 2146 16500 ; Pacheco Blvd. Transit Hub
+ 8847 17000 ; Vacaville Transportation Center
+ 2447 15989 ; Oakley PNR
+ 8645 15999 ; Trancas Intermodal
+ 1633 16010 ; Pittsburg PNR
+ 1713 16015 ; Byron PNR
+ 8109 16320 ; Delong Ave. Bus Pad
+ 7969 16305 ; Hamilton Theater PNR
+ 7869 16310 ; Greenbrae PNR's
+ 7996 16315 ; San Rafael: Lincoln & Prospect
+ 7852 16325 ; Corte Madera: Redwood & Montecito PNR
+11631 17010 ; Benicia Bus Hub
+ 2223 17020 ; Hercules Transit Center
+ 7870 17030 ; Greenbrae Sir Francis Drake Blvd at Drakes Lading Office Park
+ 7828 17035 ; Mill Valley: Miller Ave at Evergreen Ave
+ 8239 17040 ; Petaluma: South Petaluma Blvd at Hwy 101


### PR DESCRIPTION
I think there's an error in Express Bus PNR coding.

From the Cube Documentation on the PNR control statement, for the NODE keyword:
"Node to which the program generates an access link from each zone specified in ZONES via the PNR access-development process. That process builds the best highway-time path from each designated zone to this NODE using only links that exist in NETI. Normally, NODE is a transit stop node. 

However, at some locations, the NODE might not be a stop node, but merely a drop-off node, or the entrance to a parking lot associated with a transit-stop node. To accommodate the latter scenario, append a second node to the first NODE value (NODE-NODE); the program generates an additional support (lot) link between the two nodes. In either case, the nodes must exist in the highway network; simply having coordinates for the nodes will suffice for generating the lot link, but if the first node does not have NETI connections, the program cannot generate a path to it. In the two-node option, the first node should not be a transit stop node, and the second node should be. The program will issue warning messages if the inputs violate these rules. The program obtains the lot-link parameters from the statement’s TIME, ONEWAY, and LOTMODE values. The program internally maintains each zone-to-node link and each generated lot link as a support link.

Bentley recommends that you enter lot links as separate support links rather than appending a second node and having the program generate a lot link."

In the [express_bus.PNR](https://github.com/BayAreaMetro/TM1_2015_Base_Network/blob/master/trn/transit_support/express_bus.PNR) file, the reverse is true. 
That is, first nodes are: 3807, 3557, 8323, 4075, 3147, 1700, ...
Second nodes are: 12831, 12832, 12834, 12885, 12835, 12839, ...

The nodes in the first set appear in the .tpl (aka .lin) files in [transit_lines](https://github.com/BayAreaMetro/TM1_2015_Base_Network/tree/master/trn/transit_lines)
The nodes in the second set appear as PNR nodes in the BUS worksheet of [Node Description.xls](https://github.com/BayAreaMetro/TM1_2015_Base_Network/blob/master/Node%20Description.xls)

By contrast, in the[ ferry.PNR](https://github.com/BayAreaMetro/TM1_2015_Base_Network/blob/master/trn/transit_support/ferry.PNR) file, 
first nodes are: 14634, 14635, 14636, 14532, 15730, ...
second nodes are: 14604, 14605, 14606, 14502, 14612, ...

The nodes in the first set appear as PNR nodes in the FERRIES worksheet of  [Node Description.xls](https://github.com/BayAreaMetro/TM1_2015_Base_Network/blob/master/Node%20Description.xls)
The nodes in the second set appear in [Ferry.tpl](https://github.com/BayAreaMetro/TM1_2015_Base_Network/blob/master/trn/transit_lines/Ferry.tpl)

I tried to see how much effect this is having so I loaded the drive access/egress connectors into a Tableau, and then related the A/B nodes to the PNR nodes from [Node Description.xls](https://github.com/BayAreaMetro/TM1_2015_Base_Network/blob/master/Node%20Description.xls) (this excel file serves as documentation, as far as I know, but it's useful for showing what PNR nodes are associated with what modes)

In the attached image (PNR access volumes by mode), you can see there is very small volume associated with BUS PNRs, but there is also 33k drive access volume which I couldn't tell which modes they're associated with — the B node didn't come up in the workbook — so they'll require more digging.

transit access file
connects PNR to network, "background transit access link" diagram [here](https://github.com/BayAreaMetro/modeling-website/wiki/TransitNetworkCoding)
example: heavy_rail_neti_access_links.dat

PNR file
example: transitLines_heavy_rail.pnr
PNR NODE=n1-n2 TIME=t ZONES=1-1454
where n1=PNR node, n2=transit stop

Initially investigated via https://app.asana.com/0/1201809392759895/1204133370132356/f